### PR TITLE
Fix broken link

### DIFF
--- a/ownership/builders.html
+++ b/ownership/builders.html
@@ -190,7 +190,7 @@ treatment of ownership, as described below.</p>
                            href="#non-consuming-builders-(preferred):">Non-consuming builders (preferred):</a></h3>
 <p>In some cases, constructing the final <code>T</code> does not require the builder itself to
 be consumed. The follow variant on
-<a href="http://static.rust-lang.org/doc/master/std/io/process/struct.Command.html"><code>std::io::process::Command</code></a>
+<a href="http://doc.rust-lang.org/std/process/struct.Command.html"><code>std::process::Command</code></a>
 is one example:</p>
 <pre class='rust '>
 <span class='comment'>// NOTE: the actual Command API does not use owned Strings;</span>


### PR DESCRIPTION
This link to the `Command` API documentation is broken (still refers to the older `std::io::process` instead of the current `std::process`).
