### PR TITLE
update various broken links to add /tech/

### DIFF
--- a/tech/_posts/2018-02-09-amazing-week.md
+++ b/tech/_posts/2018-02-09-amazing-week.md
@@ -53,4 +53,4 @@ like the list above, can blow you away.
 [a brilliant way to make "context arguments" more ergonomic]: https://github.com/rust-lang-nursery/futures-rfcs/pull/2#issuecomment-363923477
 [0.2 branch]: https://github.com/rust-lang-nursery/futures-rs/tree/0.2
 [leading the 2018 Domain Working Groups]: https://internals.rust-lang.org/t/announcing-the-2018-domain-working-groups/6737
-[the vision we've been working toward]: http://aturon.github.io/2018/02/06/portability-vision/
+[the vision we've been working toward]: http://aturon.github.io/tech/2018/02/06/portability-vision/

--- a/tech/_posts/2018-04-05-sound-specialization.md
+++ b/tech/_posts/2018-04-05-sound-specialization.md
@@ -217,7 +217,7 @@ solution would have to be "obviously" sound -- no clever tricks. The
 `specialize` modality has a very natural interpretation in Chalk, where we are
 already juggling [other modalities related to crate-local reasoning][negative].
 
-[negative]: https://aturon.github.io/2017/04/24/negative-chalk/
+[negative]: https://aturon.github.io/tech/2017/04/24/negative-chalk/
 
 Finally, it's worth saying that the particular mechanism here is orthogonal to
 the many other design questions around specialization, including things like

--- a/tech/_posts/2018-04-05-workflows.md
+++ b/tech/_posts/2018-04-05-workflows.md
@@ -73,7 +73,7 @@ metapackages could more generally be a way of *abstracting a chunk of
 `Cargo.toml`*, including not just normal dependencies, but also tasks, build
 scripts, and more.
 
-[metapackages]: http://aturon.github.io/2016/07/27/rust-platform/
+[metapackages]: http://aturon.github.io/tech/2016/07/27/rust-platform/
 
 In this brave new world, a single dependency entry in `Cargo.toml` is generally
 all that is ever needed to bring in a conceptual package.

--- a/tech/_posts/2018-04-06-futures2.md
+++ b/tech/_posts/2018-04-06-futures2.md
@@ -5,7 +5,7 @@ title:  "Futures 0.2 is here!"
 
 As of this morning, the futures crate version 0.2.0 is now available on
 crates.io! You can get the full low-down on the changes
-from [my earlier post](http://aturon.github.io/2018/02/27/futures-0-2-RC/); here
+from [my earlier post](http://aturon.github.io/tech/2018/02/27/futures-0-2-RC/); here
 I’ll review the overall roadmap and what this release means.
 
 **Our goal is to ship async/await in Rust 2018 (roughly by mid-September), and

--- a/tech/_posts/2018-05-25-listening-part-1.md
+++ b/tech/_posts/2018-05-25-listening-part-1.md
@@ -3,7 +3,7 @@ layout: post
 title:  "aturon.log: listening and trust, part 1"
 ---
 
-For me, most weeks working on Rust are fun — [exhilarating, even](http://aturon.github.io/2018/02/09/amazing-week/). But, just like with anything else, some weeks are hard.
+For me, most weeks working on Rust are fun — [exhilarating, even](http://aturon.github.io/tech/2018/02/09/amazing-week/). But, just like with anything else, some weeks are hard.
 
 As this week draws to a close, I feel troubled. On the one hand, things are looking strong for the 2018 Edition (which I want to write more about soon). But on the other hand, this week I locked two RFC threads, flagged a bunch of comments for moderation, and generally absorbed a lot of emotion from a lot of different quarters of the community. There’s a sense of simmering distrust.
 
@@ -65,4 +65,4 @@ So with all of that, why am I troubled? Because I’m seeing increasing signs of
 
 The Rust community prides itself on being a friendly and welcoming place, but it’s going to take constant, explicit work to keep it that way — and part of that work is being forthright about the cases where things have gotten less than friendly, pausing and working together to figure out why.
 
-In the [next post](http://aturon.github.io/2018/06/02/listening-part-2/) on this topic, I plan to focus on the kinds of breakdown I’ve been seeing, and some of my hypotheses about the underlying causes.
+In the [next post](http://aturon.github.io/tech/2018/06/02/listening-part-2/) on this topic, I plan to focus on the kinds of breakdown I’ve been seeing, and some of my hypotheses about the underlying causes.

--- a/tech/_posts/2018-06-02-listening-part-2.md
+++ b/tech/_posts/2018-06-02-listening-part-2.md
@@ -3,7 +3,7 @@ layout: post
 title:  "aturon.log: listening and trust, part 2"
 ---
 
-In [the previous post](http://aturon.github.io/2018/05/25/listening-part-1/) in
+In [the previous post](http://aturon.github.io/tech/2018/05/25/listening-part-1/) in
 this series, I recounted an early lesson for the Rust Core Team about working in
 the open. In this post, I want to talk about the delicate interplay between
 listening and trust when doing design in the open.
@@ -191,6 +191,6 @@ strong belief that doing so will lead to strictly better ideas and decisions**,
 enabling us to find positive-sum outcomes. But I also think it's vital for
 keeping our plural community whole and inclusive.
 
-In the [next post](http://aturon.github.io/2018/06/18/listening-part-3/) in 
+In the [next post](http://aturon.github.io/tech/2018/06/18/listening-part-3/) in
 this series, I'll present some concrete case studies from Rust's past and present,
 examining how the discussions functioned and what we might learn from them.

--- a/tech/_posts/2018-06-18-listening-part-3.md
+++ b/tech/_posts/2018-06-18-listening-part-3.md
@@ -7,7 +7,7 @@ title:  "aturon.log: listening and trust, part 3"
 [2017 roadmap]: https://github.com/rust-lang/rfcs/pull/1774
 [confusing]: https://withoutboats.github.io/blog/rust/2017/01/04/the-rust-module-system-is-too-confusing.html
 [inverting]: https://internals.rust-lang.org/t/lang-team-minutes-the-module-system-and-inverting-the-meaning-of-public/4804/
-[series]: http://aturon.github.io/2018/05/25/listening-part-1/
+[series]: http://aturon.github.io/tech/2018/05/25/listening-part-1/
 
 In this third post in the [listening and trust series][series],
 I'm going to talk through one of the most intense discussions the Rust community has had:
@@ -261,7 +261,7 @@ dialogue above. But even better if we can each do some of that work privately
 rather "I'm concerned about refactoring workflows; here's what my personal one
 looks like..."
 
-[last post]: http://aturon.github.io/2018/06/02/listening-part-2/
+[last post]: http://aturon.github.io/tech/2018/06/02/listening-part-2/
 
 ---
 


### PR DESCRIPTION
Example:
http://aturon.github.io/2018/05/25/listening-part-1/ ->
http://aturon.github.io/tech/2018/05/25/listening-part-1/

Thanks very much for all your great posts!

This PR fixes a bunch of links - looks like you moved
a lot of things under /tech/ at some point.
